### PR TITLE
Locked in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
   "author": "Reference Data",
   "license": "MIT",
   "dependencies": {
-    "@hmcts/properties-volume": "^1.1.0",
-    "@slack/bolt": "^4.0.0",
-    "@types/config": "^3.3.4",
-    "@types/jira-client": "^7.1.9",
-    "applicationinsights": "^2.9.5",
-    "config": "^4.0.0",
-    "jira-client": "^8.2.2",
-    "js-yaml": "^4.1.0",
-    "lodash": "^4.17.21"
+    "@hmcts/properties-volume": "1.1.0",
+    "@slack/bolt": "4.0.0",
+    "@types/config": "3.3.4",
+    "@types/jira-client": "7.1.9",
+    "applicationinsights": "2.9.5",
+    "config": "4.0.0",
+    "jira-client": "8.2.2",
+    "js-yaml": "4.1.0",
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "jest": "30.1.3",


### PR DESCRIPTION
### Change description

Update package.json to use specific versions of libs instead of '^' due to:
https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
